### PR TITLE
Introduce routes for each board

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,11 +11,11 @@
             "elm/html": "1.0.0",
             "elm/parser": "1.1.0",
             "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
             "elm-community/list-extra": "8.2.2"
         },
         "indirect": {
             "elm/json": "1.1.2",
-            "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }
     },

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,16 +1,18 @@
 module Main exposing (main)
 
 import Browser
-import Model
+import Model exposing (Msg(..))
 import Update
 import View
 
 
-main : Program Model.Flags Model.Model Update.Msg
+main : Program Model.Flags Model.Model Model.Msg
 main =
-    Browser.element
+    Browser.application
         { view = View.view
         , init = Update.init
         , update = Update.update
         , subscriptions = Update.subscriptions
+        , onUrlChange = ChangedUrl
+        , onUrlRequest = ClickedLink
         }

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -1,49 +1,86 @@
 module Model exposing
     ( Flags
-    , Model
-    , initial
-    , nextBoard
+    , Model(..)
+    , Msg(..)
+    , changeRouteTo
+    , toSession
     )
 
+import Browser
 import Game
-import Levels
+import Page.Board.Main as Board
+import Page.Home.Main as Home
+import Route exposing (Route)
+import Session
+import Url exposing (Url)
 
 
 type alias Flags =
     ()
 
 
-type alias Model =
-    { game : Game.Game
-    , boards : List Game.Board
-    }
+type Model
+    = Home Home.Model
+    | NotFound Session.Model
+    | Loading Session.Model
+    | Board Board.Model
 
 
-initial : Model
-initial =
-    { game = Game.NotStarted
-    , boards = Game.loadBoards Levels.levels
-    }
+type Msg
+    = HandleHomeMsg Home.Msg
+    | HandleBoardMsg Board.Msg
+    | ChangedUrl Url
+    | ClickedLink Browser.UrlRequest
 
 
-currentBoard : Model -> Maybe Game.Board
-currentBoard { game } =
-    case game of
-        Game.NotStarted ->
-            Nothing
+toSession : Model -> Session.Model
+toSession model =
+    case model of
+        Home { session } ->
+            session
 
-        Game.Started board ->
-            Just board
+        NotFound session ->
+            session
 
-        Game.Complete board _ _ ->
-            Just board
+        Loading session ->
+            session
+
+        Board { session } ->
+            session
 
 
-nextBoard : Model -> Maybe Game.Board
-nextBoard ({ boards } as model) =
-    currentBoard model
-        |> Maybe.andThen
-            (\board ->
-                List.filter (\b -> Game.getBoardId b == Game.advanceBoardId (Game.getBoardId board)) boards
-                    |> List.head
-            )
+changeRouteTo : Maybe Route -> Model -> ( Model, Cmd Msg )
+changeRouteTo maybeRoute model =
+    let
+        session =
+            toSession model
+    in
+    case maybeRoute of
+        Nothing ->
+            ( NotFound session, Cmd.none )
+
+        Just Route.Home ->
+            Home.init session
+                |> updateWith Home HandleHomeMsg
+
+        Just (Route.ShowBoard boardId) ->
+            case findBoard session.boards boardId of
+                Nothing ->
+                    ( NotFound session, Cmd.none )
+
+                Just board ->
+                    Board.init session board
+                        |> updateWith Board HandleBoardMsg
+
+
+findBoard : List Game.Board -> Game.BoardId -> Maybe Game.Board
+findBoard boards boardId =
+    List.filter (\b -> Game.getBoardId b == boardId) boards
+        |> List.head
+
+
+updateWith : (subModel -> Model) -> (subMsg -> Msg) -> ( subModel, Cmd subMsg ) -> ( Model, Cmd Msg )
+updateWith toModel toMsg ( subModel, subCmd ) =
+    ( toModel subModel
+    , Cmd.map toMsg subCmd
+    )

--- a/src/Page/Board/Main.elm
+++ b/src/Page/Board/Main.elm
@@ -1,0 +1,156 @@
+module Page.Board.Main exposing
+    ( Model
+    , Msg(..)
+    , init
+    , subscriptions
+    , update
+    , view
+    )
+
+import Direction
+import Game
+import Html exposing (..)
+import Html.Attributes exposing (class, classList)
+import Html.Events exposing (onClick)
+import Obstacle exposing (Obstacle(..))
+import Particle exposing (Particle)
+import Route
+import Session exposing (WithSession)
+import Time
+
+
+type alias Model =
+    WithSession { game : Game.Game }
+
+
+type Msg
+    = ClickObstacle (Maybe Obstacle)
+    | AdvanceBoard
+
+
+init : Session.Model -> Game.Board -> ( Model, Cmd Msg )
+init session board =
+    ( { session = session, game = Game.Started board }, Cmd.none )
+
+
+nextBoard : Model -> Maybe Game.Board
+nextBoard model =
+    let
+        boards =
+            model.session.boards
+
+        currentBoard =
+            Game.gameBoard model.game
+    in
+    List.filter (\b -> Game.getBoardId b == Game.advanceBoardId (Game.getBoardId currentBoard)) boards
+        |> List.head
+
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+    Time.every 600 (always AdvanceBoard)
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        ClickObstacle (Just (Cluster _ coordinates)) ->
+            ( { model
+                | game =
+                    Game.mapBoard (Game.incrementClicksOnCluster coordinates) model.game
+              }
+            , Cmd.none
+            )
+
+        ClickObstacle _ ->
+            ( model, Cmd.none )
+
+        AdvanceBoard ->
+            let
+                newGame =
+                    Game.mapBoard Game.advanceBoard model.game
+                        |> Game.completeGameWhenNoClustersRemain
+            in
+            ( { model | game = newGame }, Cmd.none )
+
+
+view : Model -> Html Msg
+view ({ game } as model) =
+    case game of
+        Game.Started board ->
+            div []
+                [ h2 [] [ text <| "Clicks: " ++ (String.fromInt <| Game.clicksMade game) ]
+                , h2 [] [ text <| "Par: " ++ (String.fromInt <| Game.parForBoard board) ]
+                , endGameLink
+                , renderBoard <| Game.renderableBoard board
+                ]
+
+        Game.Complete board _ _ ->
+            div []
+                [ h2 [] [ text <| "Complete! Clicks: " ++ (String.fromInt <| Game.clicksMade game) ]
+                , endGameLink
+                , nextBoardButton model
+                , renderBoard <| Game.renderableBoard board
+                ]
+
+
+endGameLink : Html a
+endGameLink =
+    a [ Route.href Route.Home ] [ text "End game" ]
+
+
+nextBoardButton : Model -> Html Msg
+nextBoardButton model =
+    case nextBoard model of
+        Just nextBoard_ ->
+            a [ Route.href <| Route.ShowBoard <| Game.getBoardId nextBoard_ ] [ text "Go on to next board" ]
+
+        Nothing ->
+            text ""
+
+
+obstacleClass : Obstacle -> List String
+obstacleClass obstacle =
+    case obstacle of
+        Cluster size _ ->
+            [ "cluster", "cluster-" ++ Obstacle.showSize size ]
+
+        Portal _ _ ->
+            [ "portal" ]
+
+        Mirror _ ->
+            [ "mirror" ]
+
+        MirrorLeft _ ->
+            [ "mirror-left" ]
+
+        MirrorRight _ ->
+            [ "mirror-right" ]
+
+        ChangeDirection direction _ ->
+            [ "change-direction", "change-direction-" ++ Direction.showDirection direction ]
+
+        BlackHole _ ->
+            [ "black-hole" ]
+
+        Energizer _ ->
+            [ "energizer" ]
+
+
+renderBoard : List (List ( List Particle, Maybe Obstacle )) -> Html Msg
+renderBoard boardTiles =
+    let
+        renderRow columns =
+            tr [] (List.map renderColumn columns)
+
+        classes particles obstacle =
+            (Maybe.withDefault [] <| Maybe.map (\o -> List.map (\s -> ( s, True )) <| obstacleClass o) obstacle) ++ [ ( "has-particle", List.length particles > 0 ) ]
+
+        renderColumn ( particles, obstacle ) =
+            td [ classList <| classes particles obstacle, onClick <| ClickObstacle obstacle ]
+                [ span [] (List.map showParticle particles) ]
+
+        showParticle particle =
+            span [ class <| "particle particle-" ++ (Direction.showDirection <| Particle.particleDirection particle) ] []
+    in
+    table [ class "board" ] (List.map renderRow boardTiles)

--- a/src/Page/Home/Main.elm
+++ b/src/Page/Home/Main.elm
@@ -1,0 +1,56 @@
+module Page.Home.Main exposing
+    ( Model
+    , Msg(..)
+    , init
+    , subscriptions
+    , update
+    , view
+    )
+
+import Game
+import Html exposing (..)
+import Route
+import Session exposing (WithSession)
+
+
+type alias Model =
+    WithSession {}
+
+
+type Msg
+    = NoOp
+
+
+init : Session.Model -> ( Model, Cmd Msg )
+init session =
+    ( { session = session }, Cmd.none )
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        NoOp ->
+            ( model, Cmd.none )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions =
+    always Sub.none
+
+
+view : Model -> Html Msg
+view { session } =
+    div [] (List.map displayBoard session.boards)
+
+
+displayBoard : Game.Board -> Html Msg
+displayBoard board =
+    let
+        boardId =
+            Game.getBoardId board
+    in
+    div []
+        [ a [ Route.href <| Route.ShowBoard boardId ]
+            [ text <| "Start level " ++ Game.showBoardId boardId
+            ]
+        ]

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -1,0 +1,56 @@
+module Route exposing
+    ( Route(..)
+    , fromUrl
+    , href
+    , replaceUrl
+    )
+
+import Browser.Navigation as Nav
+import Game
+import Html exposing (Attribute)
+import Html.Attributes as Attr
+import Url exposing (Url)
+import Url.Parser as Parser exposing ((</>), Parser, oneOf, s)
+
+
+type Route
+    = Home
+    | ShowBoard Game.BoardId
+
+
+parser : Parser (Route -> a) a
+parser =
+    oneOf
+        [ Parser.map Home Parser.top
+        , Parser.map ShowBoard (s "board" </> Game.boardIdUrlParser)
+        ]
+
+
+href : Route -> Attribute msg
+href targetRoute =
+    Attr.href (routeToString targetRoute)
+
+
+replaceUrl : Nav.Key -> Route -> Cmd msg
+replaceUrl key route =
+    Nav.replaceUrl key (routeToString route)
+
+
+fromUrl : Url -> Maybe Route
+fromUrl url =
+    { url | path = Maybe.withDefault "" url.fragment, fragment = Nothing }
+        |> Parser.parse parser
+
+
+routeToString : Route -> String
+routeToString page =
+    let
+        pieces =
+            case page of
+                Home ->
+                    []
+
+                ShowBoard boardId ->
+                    [ "board", Game.showBoardId boardId ]
+    in
+    "#/" ++ String.join "/" pieces

--- a/src/Session.elm
+++ b/src/Session.elm
@@ -1,0 +1,32 @@
+module Session exposing
+    ( Model
+    , WithSession
+    , initial
+    , navKey
+    )
+
+import Browser.Navigation as Nav
+import Game
+import Levels
+
+
+type alias WithSession a =
+    { a | session : Model }
+
+
+type alias Model =
+    { key : Nav.Key
+    , boards : List Game.Board
+    }
+
+
+initial : Nav.Key -> Model
+initial key =
+    { key = key
+    , boards = Game.loadBoards Levels.levels
+    }
+
+
+navKey : Model -> Nav.Key
+navKey { key } =
+    key

--- a/src/View.elm
+++ b/src/View.elm
@@ -1,103 +1,29 @@
 module View exposing (view)
 
-import Direction
-import Game
+import Browser
 import Html exposing (..)
-import Html.Attributes exposing (class, classList)
-import Html.Events exposing (onClick)
-import Model exposing (Model)
-import Obstacle exposing (Obstacle(..))
-import Particle exposing (Particle)
-import Update exposing (Msg(..))
+import Model exposing (Model(..), Msg(..))
+import Page.Board.Main as Board
+import Page.Home.Main as Home
 
 
-displayBoard : Int -> Game.Board -> Html Msg
-displayBoard index board =
-    div []
-        [ button [ onClick <| StartGame board ] [ text <| "Start game " ++ String.fromInt index ]
-        ]
-
-
-view : Model -> Html Msg
+view : Model -> Browser.Document Msg
 view model =
-    case model.game of
-        Game.NotStarted ->
-            div [] (List.indexedMap displayBoard model.boards)
+    { title = "Reaction"
+    , body =
+        [ div []
+            [ case model of
+                Home homeModel ->
+                    Html.map HandleHomeMsg <| Home.view homeModel
 
-        Game.Started board ->
-            div []
-                [ h2 [] [ text <| "Clicks: " ++ (String.fromInt <| Game.clicksMade model.game) ]
-                , h2 [] [ text <| "Par: " ++ (String.fromInt <| Game.parForBoard board) ]
-                , endGameButton
-                , renderBoard <| Game.renderableBoard board
-                ]
+                Board boardModel ->
+                    Html.map HandleBoardMsg <| Board.view boardModel
 
-        Game.Complete board _ _ ->
-            div []
-                [ h2 [] [ text <| "Complete! Clicks: " ++ (String.fromInt <| Game.clicksMade model.game) ]
-                , endGameButton
-                , nextBoardButton model
-                , renderBoard <| Game.renderableBoard board
-                ]
+                NotFound _ ->
+                    text "not found"
 
-
-endGameButton : Html Msg
-endGameButton =
-    button [ onClick EndGame ] [ text "End game" ]
-
-
-nextBoardButton : Model -> Html Msg
-nextBoardButton model =
-    case Model.nextBoard model of
-        Just nextBoard_ ->
-            button [ onClick <| StartGame nextBoard_ ] [ text "Go on to next board" ]
-
-        Nothing ->
-            text ""
-
-
-obstacleClass : Obstacle -> List String
-obstacleClass obstacle =
-    case obstacle of
-        Cluster size _ ->
-            [ "cluster", "cluster-" ++ Obstacle.showSize size ]
-
-        Portal _ _ ->
-            [ "portal" ]
-
-        Mirror _ ->
-            [ "mirror" ]
-
-        MirrorLeft _ ->
-            [ "mirror-left" ]
-
-        MirrorRight _ ->
-            [ "mirror-right" ]
-
-        ChangeDirection direction _ ->
-            [ "change-direction", "change-direction-" ++ Direction.showDirection direction ]
-
-        BlackHole _ ->
-            [ "black-hole" ]
-
-        Energizer _ ->
-            [ "energizer" ]
-
-
-renderBoard : List (List ( List Particle, Maybe Obstacle )) -> Html Msg
-renderBoard boardTiles =
-    let
-        renderRow columns =
-            tr [] (List.map renderColumn columns)
-
-        classes particles obstacle =
-            (Maybe.withDefault [] <| Maybe.map (\o -> List.map (\s -> ( s, True )) <| obstacleClass o) obstacle) ++ [ ( "has-particle", List.length particles > 0 ) ]
-
-        renderColumn ( particles, obstacle ) =
-            td [ classList <| classes particles obstacle, onClick <| ClickObstacle obstacle ]
-                [ span [] (List.map showParticle particles) ]
-
-        showParticle particle =
-            span [ class <| "particle particle-" ++ (Direction.showDirection <| Particle.particleDirection particle) ] []
-    in
-    table [ class "board" ] (List.map renderRow boardTiles)
+                Loading _ ->
+                    text "loading"
+            ]
+        ]
+    }


### PR DESCRIPTION
What?
=====

This breaks apart the application into multiple pages, following TEA, in
order to make individual game boards routeable.